### PR TITLE
Fix FoundationDB alias typo

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	foundeationDB "github.com/apple/foundationdb/bindings/go/src/fdb"
+	foundationDB "github.com/apple/foundationdb/bindings/go/src/fdb"
 	"github.com/kelseyhightower/envconfig"
 	"github.com/sashabaranov/go-openai"
 	"github.com/sideshow/apns2"
@@ -45,9 +45,9 @@ func main() {
 
 	logrusLogger := logrus.New()
 	logrusLogger.SetLevel(cfg.LoggerLevel)
-	foundeationDB.MustAPIVersion(foundationDBVersion)
+	foundationDB.MustAPIVersion(foundationDBVersion)
 
-	db, err := foundeationDB.OpenDatabase(cfg.DatabasePath)
+	db, err := foundationDB.OpenDatabase(cfg.DatabasePath)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
## Summary
- fix misspelled alias for FoundationDB in `cmd/server/main.go`
- update references to use the corrected alias

## Testing
- `go test ./...` *(fails: foundationdb headers missing, invalid API key)*

------
https://chatgpt.com/codex/tasks/task_e_68473a0d5aa08325b3dec75dfdc83907