### PR TITLE
Fix auth comment about getSecret

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -55,7 +55,7 @@ func (a *auth) Validate(_ context.Context, jwtToken string) (*common.User, error
 			return nil, fmt.Errorf("Unexpected signing method: %v.", token.Header["alg"])
 		}
 
-		// hmacSampleSecret is a []byte containing your secret, e.g. []byte("my_secret_key")
+		// getSecret() returns the ECDSA private key used for signing and verification
 		key, err := a.getSecret()
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
## Summary
- update auth comment to clarify that `getSecret()` returns the ECDSA key used for signing and verifying tokens

## Testing
- `go test ./...` *(fails: foundationdb C library missing)*

------
https://chatgpt.com/codex/tasks/task_e_68473a291e188325ae25ee2741297704