### PR TITLE
Fix notifications decode pointer usage

### DIFF
--- a/common/key_value/encoder/encoder_test.go
+++ b/common/key_value/encoder/encoder_test.go
@@ -28,4 +28,14 @@ func TestDecode(t *testing.T) {
 		require.NoError(t, Decode(data, &el))
 		assert.Equal(t, input, el)
 	})
+	t.Run("decode uuids without pointer", func(t *testing.T) {
+		input := []uuid.UUID{uuid.New()}
+		data, err := json.Marshal(input)
+		require.NoError(t, err)
+
+		var el []uuid.UUID
+		err = Decode(data, el)
+		assert.Error(t, err)
+		assert.Empty(t, el)
+	})
 }

--- a/pkg/fdb/notification.go
+++ b/pkg/fdb/notification.go
@@ -119,7 +119,7 @@ func (d *db) Notifications(ctx context.Context, userID uuid.UUID) ([]common.Noti
 
 	nt := make([]uuid.UUID, 0)
 
-	if err = encoder.Decode(data, nt); err != nil {
+	if err = encoder.Decode(data, &nt); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
## Summary
- fix pointer usage when decoding notifications list
- add unit test covering pointer requirement in decoder

## Testing
- `go test ./...` *(fails: foundationdb headers missing, invalid API key)*

------
https://chatgpt.com/codex/tasks/task_e_68473a20435483258bcd93c8ac085c87