### PR TITLE
Improve openweather test

### DIFF
--- a/internal/openweather/service_test.go
+++ b/internal/openweather/service_test.go
@@ -10,10 +10,15 @@ import (
 )
 
 func Test_service_CurrentCyprus(t *testing.T) {
+	key := os.Getenv("KEY")
+	if key == "" {
+		t.Skip("OPENWEATHER key not set")
+	}
+
 	t.Run("get weather", func(t *testing.T) {
 		logger := logrus.New()
 		logger.SetLevel(logrus.DebugLevel)
-		s := NewService(os.Getenv("KEY"), logger.WithField("pkg", "openweather"))
+		s := NewService(key, logger.WithField("pkg", "openweather"))
 		_, err := s.CurrentCyprus(context.Background())
 		require.NoError(t, err)
 	})


### PR DESCRIPTION
## Summary
- only run openweather test when KEY env var is provided

## Testing
- `go test ./internal/openweather -run Test_service_CurrentCyprus -v`

------
https://chatgpt.com/codex/tasks/task_e_684742f15910832588c31b6b6af61593