### PR TITLE
Fix grammar in adviser prompt

### DIFF
--- a/internal/adviser/prompt.gotpl
+++ b/internal/adviser/prompt.gotpl
@@ -4,7 +4,7 @@ I have some criteria for choosing:
     1. Current weather: "temperature is {{ .Weather.Temperature }} °C, clouds percent is {{ .Weather.Temperature }}, {{ .Weather.Rain.String }}, humidity level is {{ .Weather.Humidity }}, wind speed is {{ .Weather.WindSpeed }} meter/sec, visibility is {{ .Weather.Visibility }} meters"
     2. Current time of day: {{ .TimeOfDay }}
 {{- if .Feelings.NotEmpty }}
-    3. I feeling {{ .Feelings }}
+    3. I’m feeling {{ .Feelings }}
 {{- end}}
 
 Can you recommend tea for me?


### PR DESCRIPTION
## Summary
- correct sentence grammar in adviser prompt template

## Testing
- `go test ./...` *(fails: foundationdb/fdb_c.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684740fba5e0832584fe87f80f78a43a